### PR TITLE
Fix ligand surface bug (with Claude)

### DIFF
--- a/api/coot-molecule-moltris.cc
+++ b/api/coot-molecule-moltris.cc
@@ -389,7 +389,7 @@ coot::molecule_t::get_molecular_representation_mesh(const std::string &atom_sele
                   mmdb::Residue *residue_p = chain_p->GetResidue(ires);
                   if (residue_p) {
                      int res_no = residue_p->GetSeqNum();
-                     if (residue_p->isAminoacid()) {
+                     if (! residue_p->isSolvent()) {
                         if (res_no > resno_max) resno_max = res_no;
                         if (res_no < resno_min) resno_min = res_no;
                      }
@@ -417,7 +417,7 @@ coot::molecule_t::get_molecular_representation_mesh(const std::string &atom_sele
 
       for (const auto &ch : ci) {
 
-         if (ch.resno_max <= ch.resno_min) continue;
+         if (ch.resno_max < ch.resno_min) continue;
          std::string chain_sel = "//" + std::string(ch.chain_p->GetChainID());
 
          auto ramp_cs = std::shared_ptr<ColorScheme>(new ColorScheme());


### PR DESCRIPTION
# Ligand surface mesh regression in Coot

## Summary

Commit [`44ab73bf`](https://github.com/pemsley/coot/commit/44ab73bf8b57c4cbfa2ed505e46c081635e07980)
("Fix the colour ramp") introduced a regression in
[`api/coot-molecule-moltris.cc`](https://github.com/pemsley/coot/blob/44ab73bf8b57c4cbfa2ed505e46c081635e07980/api/coot-molecule-moltris.cc)
that causes `get_molecular_representation_mesh()` to return an empty mesh
for ligand-only molecules when using `MolecularSurface` with the
`colorRampChainsScheme` colour scheme.

Detected by: [Moorhen CI run #2265](https://github.com/moorhen-coot/Moorhen/actions/runs/24142681517/job/70448162893)

## Root cause

Two changes in the `get_chains_in_selection` lambda interact to silently
skip non-protein chains:

1. **`isAminoacid()` filter** — The residue-number range (`resno_min`/`resno_max`)
   is now computed only over amino-acid residues. For a chain that contains only
   a ligand (or only nucleotides), no residue passes the filter and the range
   stays at its sentinel values (999999 / −999999).

2. **`resno_max <= resno_min` guard** — The `ramp_chains` lambda skips any chain
   where `resno_max <= resno_min`. Because the sentinels satisfy this condition,
   every non-protein chain is skipped entirely and produces zero mesh vertices.

The original code excluded only `HOH` by name, which correctly kept ligands and
nucleotides in the range calculation.

## Impact

- **Ligand surfaces are completely empty** (0 vertices / 0 triangles).
- Protein surface vertex counts shift by ~3% (143 439 → 147 864 for 5a3h)
  because non-protein residues no longer contribute to the per-chain
  colour-ramp range.

## Fix

In `api/coot-molecule-moltris.cc`, inside `get_chains_in_selection`:

```diff
-                     if (residue_p->isAminoacid()) {
+                     if (! residue_p->isSolvent()) {
```

This restores the original intent of excluding only solvent (water) from the
range, using the MMDB API instead of a hard-coded residue name.

In `ramp_chains`, relax the guard to allow single-residue chains (e.g. a lone
ligand):

```diff
-         if (ch.resno_max <= ch.resno_min) continue;
+         if (ch.resno_max < ch.resno_min) continue;
```
